### PR TITLE
remove invalid context in solar.md

### DIFF
--- a/docs/home-automation/automation/solar.md
+++ b/docs/home-automation/automation/solar.md
@@ -46,7 +46,6 @@ You can also use reference points as events!
 
 ```typescript
 automation.solar.onEvent({
-  context,
   eventName: "dawn",
   exec() {
     logger.info("It is dawn!");


### PR DESCRIPTION
I believe that solar onEvent doesn't take a context parameter in the object

## 📬 Changes

<!-- short description of what's going on, help the changelog be useful -->
removed the context parameter on the homeautomation.solar.onEvent object in the example

- ...

## 🗒️ Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [ ] Tests (added, updated or not needed)
