### PR TITLE
docs: Change mock assistant script extension from `.js` to `.mts`

### DIFF
--- a/docs/testing/automations/fixtures.md
+++ b/docs/testing/automations/fixtures.md
@@ -19,7 +19,7 @@ You can generate these types using the script.
 ```bash
 npx mock-assistant
 # or
-node node_modules/@digital-alchemy/hass/dist/mock_assistant/main.js
+node node_modules/@digital-alchemy/hass/dist/mock_assistant/main.mts
 ```
 
 The configuration file from [type-writer](/docs/home-automation/hass/setup/type-writer/) is compatible with the script.


### PR DESCRIPTION
**Note** `mock-assistant` module needs updating too as it is calling `node_modules/@digital-alchemy/hass/src/mock_assistant/main.ts`

## 📬 Changes

Updated the command to run the mock assistant script from `.js` to `.mts`.

## 🗒️ Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
