### PR TITLE
docs: library composition reference, guide, and blog

### DIFF
--- a/blog/function-vs-arrow-declaration-emit.mdx
+++ b/blog/function-vs-arrow-declaration-emit.mdx
@@ -1,0 +1,93 @@
+---
+title: "The one-keyword bug: when your library's types vanish across a package boundary"
+date: 2026-06-16
+description: "A named function and an arrow that do the exact same thing emit different .d.ts — and only one carries your types across packages. Here's the mechanism, and why it's not the distinction you think it is."
+---
+
+import EmbeddedEditor from '@site/src/components/EmbeddedEditor';
+import { files, defaultFile } from '@site/src/examples/blog/declaration-emit';
+
+Here are two services. Same body, same return type, same everything a linter or a reviewer would look at:
+
+```typescript
+export function Lights({ logger }: TServiceParams) { /* ... */ }
+export const Lights = ({ logger }: TServiceParams) => { /* ... */ };
+```
+
+Swap one for the other inside a published library, pull that library into a downstream app through `implies` (or a rollup), and the runtime is identical — but with the arrow, the app silently loses every type the library was supposed to bring. `params.lighting` goes from fully-typed to gone. Nothing errors. The build is green. The types just aren't there.
+
+I hit this building library composition for core. The cause turned out to live in one of the quieter corners of TypeScript's declaration emitter, and it's worth a writeup — because the rule people reach for ("arrows are the problem") is *wrong*, and the real rule is one line.
+
+<!--truncate-->
+
+## Why a type even needs to "travel"
+
+`TServiceParams` is assembled from the global `LoadedModules` interface. Every library extends it by declaration merging — a `declare module "@digital-alchemy/core" { interface LoadedModules { ... } }` block in the library's source. That block only takes effect if the file containing it is part of *your* compilation.
+
+When you import a library directly, you import that file, so the augmentation comes along. The interesting case is `implies`: you list library **A**, and A pulls in library **B** transitively. You never import B. For B's types to reach you, B's augmentation has to ride into your program on the back of *something you do import* — and that something is A's emitted `.d.ts`.
+
+So the whole question reduces to: **does A's `.d.ts` contain a reference back to B's module?**
+
+## What the compiler actually emits
+
+`CreateLibrary` captures `implies` as a `const` tuple, so the implier's declaration file spells out each member. Here is the real emit when the implied library's service is a **named function declaration**:
+
+```typescript title="living-room.d.mts  (member service = function declaration)"
+export declare const LIVING_ROOM: LibraryDefinition<
+  { Scenes: typeof Scenes },
+  OptionalModuleConfiguration,
+  readonly [LibraryDefinition<{
+    Lights: typeof import("./lighting.mjs").Lights;   // ← a real edge to lighting.mjs
+  }, OptionalModuleConfiguration, readonly []>]
+>;
+```
+
+That `typeof import("./lighting.mjs").Lights` is a genuine reference to the lighting module. When your program resolves it, it loads `lighting.d.mts` — which carries `declare module "@digital-alchemy/core" { interface LoadedModules { lighting } }`. The augmentation fires. `params.lighting` lights up. You never typed the word `lighting`.
+
+Now the **arrow** version of the exact same service — same logic, same shape:
+
+```typescript title="living-room.d.mts  (member service = arrow const)"
+export declare const LIVING_ROOM: LibraryDefinition<
+  { Scenes: typeof Scenes },
+  OptionalModuleConfiguration,
+  readonly [LibraryDefinition<{
+    Lights: ({ logger }: TServiceParams) => {          // ← inlined structurally, no edge
+      dim(toPercent: number): void;
+      readonly brightness: number;
+    };
+  }, OptionalModuleConfiguration, readonly []>]
+>;
+```
+
+No `import("./lighting.mjs")` anywhere. The function's *shape* got inlined instead of a reference to it. Your program never loads `lighting.d.mts`, the augmentation never runs, and `params.lighting` is untyped — even though the service wires and runs perfectly at boot. Runtime works, types vanish.
+
+## It is not "arrow vs function." It is "binding vs declaration."
+
+The reflex is to blame arrows. That's not it. I emitted four forms of the same service and checked which keep the edge:
+
+| How the service is written | Emitted in the consumer's `.d.ts` | Edge survives? |
+|---|---|---|
+| `function Svc() {}` | `Svc: typeof import("./src").Svc` | ✅ yes |
+| `const Svc = () => {}` | `Svc: (p: TServiceParams) => {…}` | ❌ no |
+| `const Svc = function () {}` | `Svc: (p: TServiceParams) => {…}` | ❌ no |
+| `const Svc = function Named() {}` | `Svc: (p: TServiceParams) => {…}` | ❌ no |
+
+Only the **function declaration** survives. A declaration gives the emitter a named symbol it can point back to — `export declare function Svc(...)`, and every reference becomes `typeof import(...).Svc`. Every `const` form emits `export declare const Svc: <structural type>` and inlines that structure at each use site. No name to point at, no import, no edge.
+
+The last row is the trap worth remembering: a **named function expression** *looks* named, but the name is internal to the expression — the binding is still a `const`, so it inlines with the rest. "It has a name" is not the property that matters. "It is a declaration" is.
+
+## See it locally — and why you can't
+
+Both files below type-check *identically* right here. That's the point: in a single program, types resolve through source, so the difference genuinely does not exist yet. Hover `Lights` in each — same inferred type. The divergence only appears once TypeScript emits `.d.ts` and a *different package* reads it.
+
+<EmbeddedEditor files={files} defaultFile={defaultFile} exampleId="blog-declaration-emit" />
+
+## The rule
+
+Write services as named `function` declarations. Not arrows, not `const x = function`. core ships a regression guard (`examples/implies-propagation`) that compiles a real two-package workspace and fails if this edge ever stops working, and there's an eslint rule — `service-factory-must-be-declaration` — so the wrong form fails in CI instead of silently dropping a downstream package's types six months from now.
+
+**Takeaways:**
+
+- A named `function` and a `const` arrow are not interchangeable in a *published* library — they emit different `.d.ts`.
+- Only the declaration form leaves an import edge, and that edge is what carries `declare module` augmentations across a package boundary.
+- "Runtime works, types vanish" downstream of a composed library? Check how its services are declared before you check anything else.

--- a/blog/implies-cross-package-types.md
+++ b/blog/implies-cross-package-types.md
@@ -107,7 +107,7 @@ This is exactly the kind of cross-package, cross-version behavior that quietly r
 
 Two things changed in core after this post was written:
 
-**`RollupLibraries` is renamed `LibraryGroup({ name?, members, registry? })`** — same semantics, new object-options signature. A named group earns a `LoadedModules` key and a `config.<name>` namespace. Adding `registry` synthesizes a `priorityInit` registry service (the "trench-coat" pattern from the plugin-registry post).
+**`RollupLibraries` is renamed `LibraryGroup({ name?, members, registry? })`** — same semantics, new object-options signature. A plain named group does **not** by itself earn a `LoadedModules` key or a `config.<name>` namespace. Only a `registry`-bearing group synthesizes a carrier library named `<name>` that earns the `LoadedModules` key and config namespace. Adding `registry: "<service-name>"` synthesizes a `priorityInit` registry service (the "trench-coat" pattern from the plugin-registry post).
 
 **`depends` now carries types AND contributes membership (closure-as-membership).** The `const` tuple capture that `implies` always had now also applies to `depends`. A library's `depends` list is pulled transitively into the wired set — you no longer hand-list transitive base libraries — and those dependencies appear on `params` as typed entries in any consumer that imports the carrier library.
 

--- a/blog/implies-cross-package-types.md
+++ b/blog/implies-cross-package-types.md
@@ -1,0 +1,102 @@
+---
+title: "Composing libraries without a type black hole: RollupLibraries, implies, and the circular dependency I had to *not* solve"
+date: 2026-06-16
+description: "Two opt-in composition primitives for Digital Alchemy, the wire-time snapshot that makes membership and ordering different problems, and why surfacing implied types automatically meant doing less, not more."
+---
+
+Once a Digital Alchemy app grows past a handful of libraries, the `libraries` array stops being a list and becomes a chore. Each plugin-like group is itself several libraries, and the application has to name every one of them, plus every transitive dependency, in one flat array. Miss one and boot throws `MISSING_DEPENDENCY`. It works, but you're hand-maintaining a dependency graph that the libraries already know.
+
+So core now has two opt-in primitives for composing that list — and getting them to carry types across a package boundary led me straight into a circular dependency I deliberately left unsolved. That second part is the interesting one.
+
+<!--truncate-->
+
+## Two axes nobody tells you are separate
+
+Bootstrapping needs two different things from you, and they're orthogonal:
+
+- **Membership** — *which* libraries exist. That's the application's `libraries` array. It has to be complete and flat.
+- **Ordering** — *what wires before what*. That's each library's own `depends` / `optionalDepends`, topologically sorted.
+
+The trap is assuming `depends` does both. It doesn't. `depends` declares an ordering edge and is *validated* against membership — but it never *adds* anything to membership. Both composition primitives below add to membership and touch ordering not at all.
+
+## `RollupLibraries` and `implies`
+
+They solve adjacent problems and feed the same resolver:
+
+| | `RollupLibraries` | `implies` |
+|---|---|---|
+| What it is | A **nameless** composition value | A field on a **named** library |
+| Use when | You want to bundle N libraries as a unit nobody injects | Loading library X should always bring Y, Z |
+| Identity | None — no `LoadedModules` key, no DI node | Rides on the carrier library's identity |
+
+```typescript
+// a group authored once, as a composable unit nobody injects directly
+export const analyticsPlugin = RollupLibraries(
+  [ANALYTICS_INGEST, ANALYTICS_API, ANALYTICS_STORE],
+  { label: "analytics" },
+);
+
+// or: a library that always drags its bundle along
+export const ANALYTICS_FRONT = CreateLibrary({
+  name: "analytics_front",
+  implies: [ANALYTICS_STORE, ANALYTICS_API],
+  services: { ... },
+});
+```
+
+Both flow into one `flattenLibraries` pass that expands every rollup and `implies` bundle into a flat, identity-deduped list of plain libraries. Dedup is by object identity, so the same singleton reached through two groups collapses to one entry. Reach a shared base through two paths — a diamond — and it's deduped with a hygiene `warn`; the boot manifest tracks provenance, so `showExtraBootStats` shows you every member and which path(s) brought it in. A rollup that transitively contains itself, or a mutual `implies` chain, throws `COMPOSITION_CYCLE` instead of looping.
+
+None of that touches ordering. Membership is resolved first; `buildSortOrder` runs afterward on the flattened set, using each member's own `depends`. Two passes, two concerns.
+
+## The part that bites silently: types across a package
+
+Membership is the easy half. The hard half is that a consumer who imports **only** the implier should also get the implied libraries' *types* — `params.analytics_store` fully typed — without importing or naming them.
+
+That's not free. `TServiceParams` is built from the global `LoadedModules` interface, which each library extends by declaration merging. An augmentation only applies if the file holding it is in your compilation. Import the implier and not the members, and by default the members' augmentations never reach you. (I wrote up [the exact emit mechanism separately](./function-vs-arrow-declaration-emit) — it hinges on whether the implier's `.d.ts` keeps a reference back to each member's module, which in turn hinges on the members using named `function` services.)
+
+The fix on the composition side is small: `CreateLibrary` captures `implies` as a `const` tuple, carried as a third type parameter on `LibraryDefinition`:
+
+```typescript
+CreateLibrary<S, C, const Implied extends readonly RollupMember[] = readonly []>(
+  options: LibraryConfigurationOptions<S, C> & { implies?: Implied },
+): LibraryDefinition<S, C, Implied>
+```
+
+Capturing the literal tuple is what makes the implier's emitted declaration spell out each member by `typeof import("./member.mjs").Service` — the edge that drags the member's augmentation into the consumer. With named-function services, `params.<member>` is typed and wired, no registration, no re-export. (Nameless rollups can't do this — they have no name and no declaration-merge identity — so they fall back to a `LoadedRollups` block. `implies` is the easier case, not the same one.)
+
+## The circular dependency I had to *not* solve
+
+My first instinct was the obvious one: derive the implied members' keys and fold their APIs straight into `TServiceParams`. Walk the `implies` tuple, pull each member's service map, intersect it in.
+
+It does not type-check, and it *can't* — it's provably circular. The key set I wanted to compute depends on resolving each member's definition; a member's definition includes its `services: ServiceMap`; and a `ServiceMap`'s functions take `TServiceParams` — the very type I was in the middle of defining. TypeScript calls it as it sees it: `TS2456`, type alias circularly references itself. Every shape of "reach into the members and surface their keys" I tried bottomed out at the same cycle.
+
+The resolution was to do **less**, not more. Don't derive keys at all. Capture the tuple, leave the members' own `declare module` augmentations exactly where they are, and let the import edge carry them. The type system already knows how to merge a `LoadedModules` augmentation it encounters — I don't have to re-surface anything; I just have to make sure the consumer's program *encounters* the member file. The tuple capture does that. The circular version was me trying to do the compiler's job; the working version is ~24 lines that let the compiler do it.
+
+That's the part I'd flag for anyone designing this kind of API: when the type you need depends on resolving the things that reference that type, stop deriving and start letting the language's own merge do the work.
+
+## Membership is not ordering — and the wire-time snapshot proves it
+
+One more subtlety that the runtime makes unavoidable. `params` is a **wire-time snapshot** — when a service wires, it's injected with the modules loaded *so far*, not a live proxy that fills in later. So a service can only call peers that wired *before* it.
+
+`implies` adds membership; it does **not** add an ordering edge. So if you `implies` a library and call into it while wiring, it may not be there yet — membership guarantees it exists *somewhere* in the boot, not that it's already up. That's what `depends` is for. The two are complementary, and a realistic library uses both:
+
+```typescript
+export const LIVING_ROOM = CreateLibrary({
+  name: "living_room",
+  depends: [LIGHTING],   // ordering: LIGHTING wires before me, so I can call it
+  implies: [LIGHTING],   // membership + types: a consumer listing only me still gets LIGHTING
+  services: { Scenes },
+});
+```
+
+Drop `implies` and the consumer has to list `LIGHTING` itself. Drop `depends` and `LIGHTING` might wire *after* `living_room`, leaving `params.lighting` undefined at call time. Membership and ordering are different questions; composition only answers the first.
+
+## Proof that ships
+
+This is exactly the kind of cross-package, cross-version behavior that quietly rots, so it ships with a guard. `examples/implies-propagation` is a real two-package workspace: a library with named-function services, an implier that `implies` it, and an app that imports **only** the implier and reads `params.lighting`. It builds against the local core, type-proves the implied member is present and genuinely typed (not `any`), then runs to show the library wired without ever being listed. It runs in CI on every PR — if a future TypeScript release stops carrying the augmentation across the edge, the job goes red instead of a downstream user finding out the hard way.
+
+**What you get:**
+
+- `libraries` arrays that compose instead of enumerate — bundle with `RollupLibraries`, or let a library drag its dependents along with `implies`.
+- Implied members typed *and* wired across a package boundary, with no manual registration — provided their services are named `function` declarations.
+- A clean split between membership and ordering, enforced by the runtime's wire-time snapshot rather than by convention.

--- a/blog/implies-cross-package-types.md
+++ b/blog/implies-cross-package-types.md
@@ -100,3 +100,25 @@ This is exactly the kind of cross-package, cross-version behavior that quietly r
 - `libraries` arrays that compose instead of enumerate — bundle with `RollupLibraries`, or let a library drag its dependents along with `implies`.
 - Implied members typed *and* wired across a package boundary, with no manual registration — provided their services are named `function` declarations.
 - A clean split between membership and ordering, enforced by the runtime's wire-time snapshot rather than by convention.
+
+---
+
+## Update (2026-06-17): `depends` now carries types too, and `RollupLibraries` is `LibraryGroup`
+
+Two things changed in core after this post was written:
+
+**`RollupLibraries` is renamed `LibraryGroup({ name?, members, registry? })`** — same semantics, new object-options signature. A named group earns a `LoadedModules` key and a `config.<name>` namespace. Adding `registry` synthesizes a `priorityInit` registry service (the "trench-coat" pattern from the plugin-registry post).
+
+**`depends` now carries types AND contributes membership (closure-as-membership).** The `const` tuple capture that `implies` always had now also applies to `depends`. A library's `depends` list is pulled transitively into the wired set — you no longer hand-list transitive base libraries — and those dependencies appear on `params` as typed entries in any consumer that imports the carrier library.
+
+The ordering-edge bit is now the *only* distinction between `depends` and `implies`:
+
+| | Membership | Ordering edge | Typed on `params` |
+|---|:---:|:---:|:---:|
+| `depends` | ✅ (transitive) | ✅ | ✅ |
+| `implies` | ✅ | ❌ | ✅ |
+| `optionalDepends` | ❌ | ✅ (if present) | ❌ |
+
+`implies` is now documented as the niche "membership without an ordering edge" escape hatch rather than a headline primitive. Prefer `depends` for the common case where you call into a peer at wiring time.
+
+The cross-package type-travel mechanism described in this post — named `function` declarations emitting real module edges — is unchanged. It now applies to both `depends` and `implies` members.

--- a/docs/core/guides/library-composition.md
+++ b/docs/core/guides/library-composition.md
@@ -1,0 +1,115 @@
+---
+title: Library Composition
+sidebar_position: 8
+description: "Membership vs ordering, RollupLibraries and implies, and the cross-package typing rule for composed libraries."
+---
+
+As an application grows into plugin-like groups — each group itself several libraries — the hand-maintained `libraries` array becomes a single flat union of *every* library plus *every* transitive dependency. This guide covers the two opt-in primitives that make that list compositional, and the one typing rule you must follow for them to work across package boundaries.
+
+## Two axes: membership and ordering
+
+Bootstrapping needs two distinct things from you, and they are orthogonal:
+
+1. **Membership** — *which* libraries exist. This is the application's `libraries` array. It must be **complete and flat**: `buildSortOrder` throws `MISSING_DEPENDENCY` for any `depends` target not present.
+2. **Ordering** — *what wires before what*. This is each library's own `depends` / `optionalDepends`, topologically sorted.
+
+`depends` does **not** pull a library into membership — it declares an ordering edge and is *validated* against the membership list. The two composition primitives below add to **membership**; neither touches ordering.
+
+```mermaid
+graph LR
+  subgraph Membership
+    L["libraries array"]
+    R["RollupLibraries()"]
+    I["implies"]
+  end
+  L --> Flatten["flatten + dedup"]
+  R --> Flatten
+  I --> Flatten
+  Flatten --> Sort["buildSortOrder (ordering, unchanged)"]
+```
+
+## `RollupLibraries` vs `implies`
+
+Both feed the same flatten-then-dedup resolver; they solve adjacent problems and are not substitutes.
+
+| | [`RollupLibraries`](../reference/libraries/rollup-libraries) | [`implies`](../reference/libraries/create-library) |
+|---|---|---|
+| What it is | A **nameless** composition value | A field on a **named** library |
+| Use when | You want to bundle N libraries as a composable unit nobody injects | Loading library X should always bring libraries Y, Z |
+| Identity | None — no `LoadedModules` key, no DI node | Rides on the carrier library's identity |
+
+```typescript
+// a group authored once, as a composable unit
+export const analyticsPlugin = RollupLibraries(
+  [ANALYTICS_INGEST, ANALYTICS_API, ANALYTICS_STORE],
+  { label: "analytics" },
+);
+
+// or: a library that always drags its bundle along
+export const ANALYTICS_FRONT = CreateLibrary({
+  name: "analytics_front",
+  implies: [ANALYTICS_STORE, ANALYTICS_API],
+  services: { ... },
+});
+```
+
+## Dedup, diamonds, and cycles
+
+- **Identity dedup.** Members must be module-singleton exports (not constructed inline), so the same library reached through two rollups collapses to one.
+- **Diamonds are fine.** When a shared base library is reached via two groups, it is deduped and boot emits a hygiene `warn` — consider declaring it a shared base dependency. With `showExtraBootStats`, the manifest shows every member and the path(s) that brought it in.
+- **Same name, different object → `DUPLICATE_LIBRARY`.** Two distinct objects sharing a name is an error, the same as listing a duplicate directly.
+- **Cycles → `COMPOSITION_CYCLE`.** A rollup that transitively contains itself, or a mutual `implies` chain.
+
+## The cross-package typing rule
+
+This is the part that bites silently if ignored.
+
+`TServiceParams` is built from the global `LoadedModules` interface, which each library extends via declaration merging. A `declare module` augmentation only takes effect when the file containing it is part of the consumer's compilation.
+
+When a downstream app imports **only a rollup** (not each member directly), TypeScript **inlines** the members' anonymous types into the rollup's emitted `.d.ts` with **no module edge** back to the member files. The members' own `LoadedModules` augmentations therefore never reach the consumer:
+
+```mermaid
+graph TD
+  App["app imports only the rollup"] -->|"value import"| Rollup["rollup.d.ts (members inlined, no edge)"]
+  Rollup -.->|"NO edge"| Member["member.d.ts (declare module LoadedModules)"]
+  Member -.->|"augmentation never arrives"| Params["TServiceParams.member → untyped"]
+```
+
+The result is "runtime works, types vanish": the services wire and run, but `params.member` is not typed.
+
+:::caution This affects the current array-spread workaround too
+Spreading plain library arrays (`libraries: [...groupA]`) has the same limitation — it only appears to work when the app *also* imports each library directly.
+:::
+
+### The fix: register on `LoadedRollups`
+
+Add a second declaration-merge, parallel to `LoadedModules`, in the module that defines the rollup. The member shapes are inlined into **this** augmentation, which travels because the consumer imports the rollup value:
+
+```typescript title="analytics/src/index.mts"
+export const analyticsPlugin = RollupLibraries([ANALYTICS_INGEST, ANALYTICS_API]);
+
+declare module "@digital-alchemy/core" {
+  export interface LoadedRollups {
+    analytics: {
+      analytics_ingest: typeof ANALYTICS_INGEST;
+      analytics_api: typeof ANALYTICS_API;
+    };
+  }
+}
+```
+
+`@digital-alchemy/core` folds every `LoadedRollups` entry into `TServiceParams`, so `params.analytics_ingest` is fully typed downstream — even when the app imports only `analyticsPlugin`.
+
+:::note `implies` usually does not need this
+The libraries in an `implies` list are named modules that the **implying** library imports directly. Because the app imports the implier (to list it), those members' `LoadedModules` augmentations travel with it. Only if an implied member is published without a named type would you also register a `LoadedRollups` block.
+:::
+
+### Membership-only consequence
+
+A library delivered **only** via a rollup has no `LoadedModules` key, so it gets service APIs on `TServiceParams` but **no** typed `config.<member>` and **no** `levelOverrides` entry. Its runtime config still loads. If you need typed config for a member, list it directly (or have it augment `LoadedModules` itself).
+
+## Related
+
+- [RollupLibraries](../reference/libraries/rollup-libraries) — API reference
+- [CreateLibrary `implies`](../reference/libraries/create-library) — the membership field
+- [Dependency Graph](../reference/libraries/dependency-graph) — ordering, which composition leaves untouched

--- a/docs/core/guides/library-composition.md
+++ b/docs/core/guides/library-composition.md
@@ -70,7 +70,7 @@ const analyticsPlugin = LibraryGroup({
   members: [ANALYTICS_INGEST, ANALYTICS_API, ANALYTICS_STORE],
 });
 
-// named group — earns a LoadedModules key and a config.<name> namespace
+// named group — no DI identity on its own; only a registry-bearing group earns a LoadedModules key
 const analyticsPlugin = LibraryGroup({
   name: "analytics",
   members: [ANALYTICS_INGEST, ANALYTICS_API, ANALYTICS_STORE],
@@ -88,7 +88,7 @@ const ANALYTICS_GROUP = LibraryGroup({
 
 ### `name` and `LoadedModules`
 
-A named group earns a `LoadedModules` key and reserves a `config.<name>` namespace. An unnamed group is still a valid membership unit — it just has no DI identity.
+A plain named group does **not** by itself earn a `LoadedModules` key or a `config.<name>` namespace. Only a `registry`-bearing group synthesizes a carrier library named `<name>` that earns the `LoadedModules` key. An unnamed group is a valid membership unit — it just has no DI identity.
 
 ### `registry` option — the plugin-registry pattern
 
@@ -118,7 +118,7 @@ export function RouterService({ analytics }: TServiceParams) {
 
 - **Identity dedup.** Members must be module-singleton exports (not constructed inline), so the same library reached through two groups or two `depends` paths collapses to one.
 - **Diamonds are fine.** When a shared base library is reached via two paths, it is deduped and boot emits a hygiene `warn` — consider declaring it a shared base dependency. With `showExtraBootStats`, the manifest shows every member and the path(s) that brought it in.
-- **Same name, different object → `DUPLICATE_LIBRARY`.** Two distinct objects sharing a name is a broken install — the error names both copies and points at `yarn dedupe`. The framework does not arbitrate between versions; the singleton-held-globally contract is deliberate.
+- **Same name, different object → `DUPLICATE_LIBRARY`.** A library is constructed once and held as a global singleton, so exactly one object boots per name. Three cases apply: (1) the library is declared in the app module → it is authoritative; (2) exactly one instance exists anywhere → it is used; (3) two distinct objects share the same name and neither is app-declared → **crash**. The error states the fact only: `Duplicate library names detected: "<name>" (×N: copy#1 vs copy#2)`. The framework deliberately does not arbitrate between versions — the package manager owns that.
 - **Cycles → `COMPOSITION_CYCLE`.** A group that transitively contains itself, or a mutual `implies`/`depends` chain.
 
 ## The cross-package typing rule
@@ -140,7 +140,13 @@ The result is "runtime works, types vanish": the services wire and run, but `par
 
 ### Type priority
 
-Directly-listed libraries and named-group members always have their `LoadedModules` augmentations applied directly. `LoadedRollups` is a **fallback** channel — it fills keys not already present from a direct listing. If a library is listed both directly and via a group, the direct listing wins.
+Directly-listed (`LoadedModules`) types win over hoisted ones. The effective merge is:
+
+```typescript
+TServiceParams = GlobalParams & Omit<RollupApis, keyof LoadedModules>
+```
+
+`LoadedRollups` is a **fallback** channel — it can only add keys not already present in `LoadedModules`. If a library is listed both directly and via a group, the direct listing wins and the fallback channel cannot override it.
 
 ### The fix: register on `LoadedRollups`
 

--- a/docs/core/guides/library-composition.md
+++ b/docs/core/guides/library-composition.md
@@ -100,23 +100,28 @@ declare module "@digital-alchemy/core" {
 
 `@digital-alchemy/core` folds every `LoadedRollups` entry into `TServiceParams`, so `params.analytics_ingest` is fully typed downstream — even when the app imports only `analyticsPlugin`.
 
-:::caution `implies` needs the same registration
-`implies` has the **same** cross-package limitation as rollups, not a lighter one. The implier's `.d.ts` carries no type edge to its implied members (the `implies` field is `RollupMember[]`, not a captured tuple), so a consumer importing only the implier gets the bundle at runtime but **not** its types — `params.member` is untyped. Register the implied bundle on `LoadedRollups` in the implier's module, exactly as shown above for a rollup.
+:::tip `implies` carries types automatically — with named `function` services
+`implies` is the **easier** case, not the same one. Unlike a nameless rollup, `CreateLibrary` captures `implies` as a `const` tuple (a third type parameter on `LibraryDefinition`), so the implier's emitted `.d.ts` references each implied member by `typeof import("./member.mjs").Service` — **a real module edge**, not an inlined anonymous shape. The member's own `LoadedModules` augmentation rides that edge into any consumer that imports only the implier, so `params.<member>` is **typed and wired** with no `LoadedRollups` block and no re-export.
 
-```typescript title="analytics/src/front.mts"
-export const ANALYTICS_FRONT = CreateLibrary({
-  name: "analytics_front",
-  implies: [ANALYTICS_STORE, ANALYTICS_API],
-  services: { ... },
-});
+The catch is the **same one** that determines whether a rollup member's types inline anonymously: it works only when the implied library's services are literal named `function` declarations.
 
-declare module "@digital-alchemy/core" {
-  interface LoadedModules { analytics_front: typeof ANALYTICS_FRONT; }
-  interface LoadedRollups {
-    analytics_front: { analytics_store: typeof ANALYTICS_STORE; analytics_api: typeof ANALYTICS_API };
-  }
-}
+```typescript title="analytics/src/store.mts"
+// ✅ named function declaration → emits `typeof import(...).Ingest`: a real edge
+export function Ingest({ logger }: TServiceParams) { /* ... */ }
+export const ANALYTICS_STORE = CreateLibrary({ name: "analytics_store", services: { Ingest } });
 ```
+
+An arrow (or anonymous / function-expression) service is serialized structurally inline with **no** import edge, so its augmentation never travels — `params.<member>` is untyped even though it wires at runtime:
+
+```typescript
+// ❌ arrow service → inlined anonymously, no edge → types do NOT travel through implies
+export const ANALYTICS_STORE = CreateLibrary({
+  name: "analytics_store",
+  services: { Ingest: ({ logger }: TServiceParams) => ({ /* ... */ }) },
+});
+```
+
+If an implied member must ship arrow/anonymous services, fall back to the rollup mechanism — register the bundle on `LoadedRollups` in the implier's module, exactly as shown above for a rollup.
 :::
 
 ### Membership-only consequence

--- a/docs/core/guides/library-composition.md
+++ b/docs/core/guides/library-composition.md
@@ -100,8 +100,23 @@ declare module "@digital-alchemy/core" {
 
 `@digital-alchemy/core` folds every `LoadedRollups` entry into `TServiceParams`, so `params.analytics_ingest` is fully typed downstream — even when the app imports only `analyticsPlugin`.
 
-:::note `implies` usually does not need this
-The libraries in an `implies` list are named modules that the **implying** library imports directly. Because the app imports the implier (to list it), those members' `LoadedModules` augmentations travel with it. Only if an implied member is published without a named type would you also register a `LoadedRollups` block.
+:::caution `implies` needs the same registration
+`implies` has the **same** cross-package limitation as rollups, not a lighter one. The implier's `.d.ts` carries no type edge to its implied members (the `implies` field is `RollupMember[]`, not a captured tuple), so a consumer importing only the implier gets the bundle at runtime but **not** its types — `params.member` is untyped. Register the implied bundle on `LoadedRollups` in the implier's module, exactly as shown above for a rollup.
+
+```typescript title="analytics/src/front.mts"
+export const ANALYTICS_FRONT = CreateLibrary({
+  name: "analytics_front",
+  implies: [ANALYTICS_STORE, ANALYTICS_API],
+  services: { ... },
+});
+
+declare module "@digital-alchemy/core" {
+  interface LoadedModules { analytics_front: typeof ANALYTICS_FRONT; }
+  interface LoadedRollups {
+    analytics_front: { analytics_store: typeof ANALYTICS_STORE; analytics_api: typeof ANALYTICS_API };
+  }
+}
+```
 :::
 
 ### Membership-only consequence

--- a/docs/core/guides/library-composition.md
+++ b/docs/core/guides/library-composition.md
@@ -1,64 +1,125 @@
 ---
 title: Library Composition
 sidebar_position: 8
-description: "Membership vs ordering, RollupLibraries and implies, and the cross-package typing rule for composed libraries."
+description: "Membership vs ordering, LibraryGroup and implies, the depends/implies/optionalDepends ordering-edge table, and the cross-package typing rule for composed libraries."
 ---
 
-As an application grows into plugin-like groups — each group itself several libraries — the hand-maintained `libraries` array becomes a single flat union of *every* library plus *every* transitive dependency. This guide covers the two opt-in primitives that make that list compositional, and the one typing rule you must follow for them to work across package boundaries.
+As an application grows into plugin-like groups — each group itself several libraries — the hand-maintained `libraries` array becomes a single flat union of *every* library plus *every* transitive dependency. This guide covers the opt-in primitives that make that list compositional, the three-way distinction between `depends`, `implies`, and `optionalDepends`, and the one typing rule you must follow for composed types to work across package boundaries.
 
 ## Two axes: membership and ordering
 
 Bootstrapping needs two distinct things from you, and they are orthogonal:
 
-1. **Membership** — *which* libraries exist. This is the application's `libraries` array. It must be **complete and flat**: `buildSortOrder` throws `MISSING_DEPENDENCY` for any `depends` target not present.
+1. **Membership** — *which* libraries exist. This is the resolved library set that the bootstrap engine flattens before wiring. It must be complete: `buildSortOrder` throws `MISSING_DEPENDENCY` for any `depends` target not reached through membership.
 2. **Ordering** — *what wires before what*. This is each library's own `depends` / `optionalDepends`, topologically sorted.
 
-`depends` does **not** pull a library into membership — it declares an ordering edge and is *validated* against the membership list. The two composition primitives below add to **membership**; neither touches ordering.
+In the redesigned model, `depends` **contributes membership** (closure-as-membership): every library in a `depends` list is transitively pulled into the wired set, so you no longer hand-list transitive base libraries in the app's `libraries` array.
 
 ```mermaid
 graph LR
   subgraph Membership
     L["libraries array"]
-    R["RollupLibraries()"]
+    G["LibraryGroup()"]
     I["implies"]
+    D["depends (closure)"]
   end
   L --> Flatten["flatten + dedup"]
-  R --> Flatten
+  G --> Flatten
   I --> Flatten
+  D --> Flatten
   Flatten --> Sort["buildSortOrder (ordering, unchanged)"]
 ```
 
-## `RollupLibraries` vs `implies`
+## `depends`, `implies`, and `optionalDepends` — one bit of difference
 
-Both feed the same flatten-then-dedup resolver; they solve adjacent problems and are not substitutes.
+All three can contribute to membership; they differ by exactly one bit — whether they add an **ordering edge**:
 
-| | [`RollupLibraries`](../reference/libraries/rollup-libraries) | [`implies`](../reference/libraries/create-library) |
-|---|---|---|
-| What it is | A **nameless** composition value | A field on a **named** library |
-| Use when | You want to bundle N libraries as a composable unit nobody injects | Loading library X should always bring libraries Y, Z |
-| Identity | None — no `LoadedModules` key, no DI node | Rides on the carrier library's identity |
+| | Contributes membership | Adds ordering edge | Typed on `params` | Missing = error |
+|---|:---:|:---:|:---:|:---:|
+| `depends` | ✅ (transitive closure) | ✅ | ✅ (`const` tuple capture) | ✅ |
+| `implies` | ✅ | ❌ | ✅ (`const` tuple capture) | — |
+| `optionalDepends` | ❌ | ✅ (if present) | ❌ | — |
+
+**`depends`** is the primary primitive. Use it when your library actively calls into a peer — the ordering edge guarantees the peer wires first, and the closure-as-membership guarantee means consumers do not need to list the peer themselves.
+
+**`implies`** is the niche "membership without an ordering edge" escape hatch. Use it when loading library X should always pull in libraries Y and Z, but X does not call Y or Z at wiring time and therefore does not care when they wire.
+
+**`optionalDepends`** orders if the library is already present (from another `depends` path), but does not pull it into membership and leaves it untyped. Use for optional integrations your service must handle being absent.
 
 ```typescript
-// a group authored once, as a composable unit
-export const analyticsPlugin = RollupLibraries(
-  [ANALYTICS_INGEST, ANALYTICS_API, ANALYTICS_STORE],
-  { label: "analytics" },
-);
-
-// or: a library that always drags its bundle along
-export const ANALYTICS_FRONT = CreateLibrary({
-  name: "analytics_front",
-  implies: [ANALYTICS_STORE, ANALYTICS_API],
-  services: { ... },
+export const LIVING_ROOM = CreateLibrary({
+  name: "living_room",
+  depends: [LIGHTING],          // ordering + membership + types; LIGHTING wires first
+  implies: [SCENES],            // membership + types; no ordering constraint
+  optionalDepends: [AUDIO],     // order if present; no pull; untyped
+  services: { Scenes },
 });
+```
+
+A realistic library that must call into a peer on wiring uses `depends`. `implies` is for bundling passengers that don't need to be ready before the carrier wires.
+
+## `LibraryGroup`
+
+`LibraryGroup` replaces the former `RollupLibraries`. It composes several libraries into a membership unit, with an optional name and an optional generated registry service.
+
+```typescript
+import { LibraryGroup, CreateApplication } from "@digital-alchemy/core";
+
+// unnamed group — membership only, no DI identity
+const analyticsPlugin = LibraryGroup({
+  members: [ANALYTICS_INGEST, ANALYTICS_API, ANALYTICS_STORE],
+});
+
+// named group — earns a LoadedModules key and a config.<name> namespace
+const analyticsPlugin = LibraryGroup({
+  name: "analytics",
+  members: [ANALYTICS_INGEST, ANALYTICS_API, ANALYTICS_STORE],
+});
+
+// registry group — named + generates a priorityInit registry service
+const ANALYTICS_GROUP = LibraryGroup({
+  name: "analytics",
+  registry: "registry",
+  members: [ANALYTICS_INGEST, ANALYTICS_API],
+});
+// Members self-register via:
+// lifecycle.onPreInit(() => parent.analytics.registry.register(...))
+```
+
+### `name` and `LoadedModules`
+
+A named group earns a `LoadedModules` key and reserves a `config.<name>` namespace. An unnamed group is still a valid membership unit — it just has no DI identity.
+
+### `registry` option — the plugin-registry pattern
+
+When `registry` is provided (requires `name`), `LibraryGroup` synthesizes a carrier library that hosts a `priorityInit` registry service. Each member is shallow-cloned with `depends: [carrier]` appended so the registry is always wired before any member reads it. The generated service exposes `register(item)` / `list()`:
+
+```typescript
+export const ANALYTICS_GROUP = LibraryGroup({
+  name: "analytics",
+  registry: "registry",
+  members: [ANALYTICS_INGEST, ANALYTICS_API],
+});
+
+// In a member's service:
+export function IngestService({ analytics, lifecycle }: TServiceParams) {
+  lifecycle.onPreInit(() => {
+    analytics.registry.register({ name: "ingest", ... });
+  });
+}
+
+// In a consumer:
+export function RouterService({ analytics }: TServiceParams) {
+  const all = analytics.registry.list();
+}
 ```
 
 ## Dedup, diamonds, and cycles
 
-- **Identity dedup.** Members must be module-singleton exports (not constructed inline), so the same library reached through two rollups collapses to one.
-- **Diamonds are fine.** When a shared base library is reached via two groups, it is deduped and boot emits a hygiene `warn` — consider declaring it a shared base dependency. With `showExtraBootStats`, the manifest shows every member and the path(s) that brought it in.
-- **Same name, different object → `DUPLICATE_LIBRARY`.** Two distinct objects sharing a name is an error, the same as listing a duplicate directly.
-- **Cycles → `COMPOSITION_CYCLE`.** A rollup that transitively contains itself, or a mutual `implies` chain.
+- **Identity dedup.** Members must be module-singleton exports (not constructed inline), so the same library reached through two groups or two `depends` paths collapses to one.
+- **Diamonds are fine.** When a shared base library is reached via two paths, it is deduped and boot emits a hygiene `warn` — consider declaring it a shared base dependency. With `showExtraBootStats`, the manifest shows every member and the path(s) that brought it in.
+- **Same name, different object → `DUPLICATE_LIBRARY`.** Two distinct objects sharing a name is a broken install — the error names both copies and points at `yarn dedupe`. The framework does not arbitrate between versions; the singleton-held-globally contract is deliberate.
+- **Cycles → `COMPOSITION_CYCLE`.** A group that transitively contains itself, or a mutual `implies`/`depends` chain.
 
 ## The cross-package typing rule
 
@@ -66,27 +127,30 @@ This is the part that bites silently if ignored.
 
 `TServiceParams` is built from the global `LoadedModules` interface, which each library extends via declaration merging. A `declare module` augmentation only takes effect when the file containing it is part of the consumer's compilation.
 
-When a downstream app imports **only a rollup** (not each member directly), TypeScript **inlines** the members' anonymous types into the rollup's emitted `.d.ts` with **no module edge** back to the member files. The members' own `LoadedModules` augmentations therefore never reach the consumer:
+When a downstream app imports **only a group** (not each member directly), TypeScript **inlines** the members' anonymous types into the group's emitted `.d.ts` with **no module edge** back to the member files. The members' own `LoadedModules` augmentations therefore never reach the consumer:
 
 ```mermaid
 graph TD
-  App["app imports only the rollup"] -->|"value import"| Rollup["rollup.d.ts (members inlined, no edge)"]
-  Rollup -.->|"NO edge"| Member["member.d.ts (declare module LoadedModules)"]
+  App["app imports only the group"] -->|"value import"| Group["group/index.d.ts (members inlined, no edge)"]
+  Group -.->|"NO edge"| Member["member.d.ts (declare module LoadedModules)"]
   Member -.->|"augmentation never arrives"| Params["TServiceParams.member → untyped"]
 ```
 
 The result is "runtime works, types vanish": the services wire and run, but `params.member` is not typed.
 
-:::caution This affects the current array-spread workaround too
-Spreading plain library arrays (`libraries: [...groupA]`) has the same limitation — it only appears to work when the app *also* imports each library directly.
-:::
+### Type priority
+
+Directly-listed libraries and named-group members always have their `LoadedModules` augmentations applied directly. `LoadedRollups` is a **fallback** channel — it fills keys not already present from a direct listing. If a library is listed both directly and via a group, the direct listing wins.
 
 ### The fix: register on `LoadedRollups`
 
-Add a second declaration-merge, parallel to `LoadedModules`, in the module that defines the rollup. The member shapes are inlined into **this** augmentation, which travels because the consumer imports the rollup value:
+Add a second declaration-merge, parallel to `LoadedModules`, in the module that defines the group. The member shapes are inlined into **this** augmentation, which travels because the consumer imports the group value:
 
 ```typescript title="analytics/src/index.mts"
-export const analyticsPlugin = RollupLibraries([ANALYTICS_INGEST, ANALYTICS_API]);
+export const analyticsPlugin = LibraryGroup({
+  name: "analytics",
+  members: [ANALYTICS_INGEST, ANALYTICS_API],
+});
 
 declare module "@digital-alchemy/core" {
   export interface LoadedRollups {
@@ -100,10 +164,10 @@ declare module "@digital-alchemy/core" {
 
 `@digital-alchemy/core` folds every `LoadedRollups` entry into `TServiceParams`, so `params.analytics_ingest` is fully typed downstream — even when the app imports only `analyticsPlugin`.
 
-:::tip `implies` carries types automatically — with named `function` services
-`implies` is the **easier** case, not the same one. Unlike a nameless rollup, `CreateLibrary` captures `implies` as a `const` tuple (a third type parameter on `LibraryDefinition`), so the implier's emitted `.d.ts` references each implied member by `typeof import("./member.mjs").Service` — **a real module edge**, not an inlined anonymous shape. The member's own `LoadedModules` augmentation rides that edge into any consumer that imports only the implier, so `params.<member>` is **typed and wired** with no `LoadedRollups` block and no re-export.
+:::tip `depends` and `implies` carry types automatically — with named `function` services
+Both `depends` and `implies` are captured as `const` tuples on `LibraryDefinition` (via a type parameter). The carrier's emitted `.d.ts` references each dependency and each implied member by `typeof import("./member.mjs").Service` — **a real module edge**, not an inlined anonymous shape. The member's own `LoadedModules` augmentation rides that edge into any consumer that imports only the carrier, so `params.<member>` is **typed and wired** with no `LoadedRollups` block and no re-export.
 
-The catch is the **same one** that determines whether a rollup member's types inline anonymously: it works only when the implied library's services are literal named `function` declarations.
+The catch: it works only when the dependency's / implied library's services are literal named `function` declarations.
 
 ```typescript title="analytics/src/store.mts"
 // ✅ named function declaration → emits `typeof import(...).Ingest`: a real edge
@@ -114,22 +178,22 @@ export const ANALYTICS_STORE = CreateLibrary({ name: "analytics_store", services
 An arrow (or anonymous / function-expression) service is serialized structurally inline with **no** import edge, so its augmentation never travels — `params.<member>` is untyped even though it wires at runtime:
 
 ```typescript
-// ❌ arrow service → inlined anonymously, no edge → types do NOT travel through implies
+// ❌ arrow service → inlined anonymously, no edge → types do NOT travel through depends/implies
 export const ANALYTICS_STORE = CreateLibrary({
   name: "analytics_store",
   services: { Ingest: ({ logger }: TServiceParams) => ({ /* ... */ }) },
 });
 ```
 
-If an implied member must ship arrow/anonymous services, fall back to the rollup mechanism — register the bundle on `LoadedRollups` in the implier's module, exactly as shown above for a rollup.
+If a depended-on or implied member must ship arrow/anonymous services, fall back to the `LoadedRollups` mechanism — register the bundle on `LoadedRollups` in the carrier's module, exactly as shown above.
 :::
 
 ### Membership-only consequence
 
-A library delivered **only** via a rollup has no `LoadedModules` key, so it gets service APIs on `TServiceParams` but **no** typed `config.<member>` and **no** `levelOverrides` entry. Its runtime config still loads. If you need typed config for a member, list it directly (or have it augment `LoadedModules` itself).
+A library delivered **only** via an unnamed group or via `implies` has no `LoadedModules` key, so it gets service APIs on `TServiceParams` but **no** typed `config.<member>` and **no** `levelOverrides` entry. Its runtime config still loads. If you need typed config for a member, list it directly.
 
 ## Related
 
-- [RollupLibraries](../reference/libraries/rollup-libraries) — API reference
-- [CreateLibrary `implies`](../reference/libraries/create-library) — the membership field
+- [LibraryGroup](../reference/libraries/rollup-libraries) — API reference
+- [CreateLibrary `implies` / `depends`](../reference/libraries/create-library) — the membership fields
 - [Dependency Graph](../reference/libraries/dependency-graph) — ordering, which composition leaves untouched

--- a/docs/core/reference/libraries/create-library.md
+++ b/docs/core/reference/libraries/create-library.md
@@ -77,8 +77,10 @@ export const ANALYTICS_FRONT = CreateLibrary({
 
 Rollups ([`RollupLibraries`](./rollup-libraries)) are accepted in `implies` and are flattened recursively.
 
-:::caution Types of implied members across packages
-`implies` has the **same** cross-package typing limitation as rollups. The implier's emitted `.d.ts` carries no type edge to its implied members (the `implies` field is `RollupMember[]`, not a captured tuple), so a consumer that imports *only* the implier does **not** receive the members' types — they wire at runtime, but `params.member` is untyped. To expose them, register the bundle on `LoadedRollups` in the implier's module, exactly like a rollup. See [Library composition](../../guides/library-composition).
+:::tip Types of implied members travel automatically — with named `function` services
+`CreateLibrary` captures `implies` as a `const` tuple (a third type parameter on `LibraryDefinition`), so the implier's emitted `.d.ts` references each implied member by `typeof import("./member.mjs").Service` — a real module edge. The member's own `LoadedModules` augmentation rides that edge, so a consumer that imports **only** the implier gets each member's service APIs on `TServiceParams`, both **typed and wired**, with no `LoadedRollups` block and no manual re-export.
+
+This holds **only when the implied library's services are literal named `function` declarations**. An arrow / anonymous service is serialized structurally inline with no import edge, so its augmentation never travels — the member still wires, but `params.member` is untyped. For an implied member that must ship arrow services, fall back to registering the bundle on `LoadedRollups`, like a nameless rollup. See [Library composition](../../guides/library-composition).
 :::
 
 ### `priorityInit`

--- a/docs/core/reference/libraries/create-library.md
+++ b/docs/core/reference/libraries/create-library.md
@@ -77,8 +77,8 @@ export const ANALYTICS_FRONT = CreateLibrary({
 
 Rollups ([`RollupLibraries`](./rollup-libraries)) are accepted in `implies` and are flattened recursively.
 
-:::note Types of implied members
-Because the implied libraries are named modules that the implying library imports directly, their `LoadedModules` augmentations travel with it — so their service APIs appear on `TServiceParams` for any app that includes the implier. See [Library composition](../../guides/library-composition) for the full cross-package typing rule.
+:::caution Types of implied members across packages
+`implies` has the **same** cross-package typing limitation as rollups. The implier's emitted `.d.ts` carries no type edge to its implied members (the `implies` field is `RollupMember[]`, not a captured tuple), so a consumer that imports *only* the implier does **not** receive the members' types — they wire at runtime, but `params.member` is untyped. To expose them, register the bundle on `LoadedRollups` in the implier's module, exactly like a rollup. See [Library composition](../../guides/library-composition).
 :::
 
 ### `priorityInit`

--- a/docs/core/reference/libraries/create-library.md
+++ b/docs/core/reference/libraries/create-library.md
@@ -27,60 +27,67 @@ export const MY_LIB = CreateLibrary({
 | `name` | `keyof LoadedModules` | ✅ | Library name — must match the key in `LoadedModules` |
 | `services` | `ServiceMap` | ✅ | Service functions exposed by this library |
 | `configuration` | `ModuleConfiguration` | — | Config entry declarations for this library |
-| `depends` | `LibraryDefinition[]` | — | Hard dependencies — must also be in the app's `libraries` array |
-| `optionalDepends` | `LibraryDefinition[]` | — | Soft dependencies — wired first if present, no error if absent |
-| `implies` | `(LibraryDefinition \| LibraryRollup)[]` | — | Transitive bundle — libraries pulled into *membership* (not ordering) when this one loads |
+| `depends` | `LibraryDefinition[]` | — | Hard dependencies — pulled into membership transitively; adds an ordering edge |
+| `optionalDepends` | `LibraryDefinition[]` | — | Soft dependencies — ordered first if present; no membership pull; stays untyped |
+| `implies` | `(LibraryDefinition \| LibraryGroup)[]` | — | Membership-only bundle — pulled into membership with no ordering edge |
 | `priorityInit` | `string[]` | — | Services to wire first within this library |
 
-### `depends` vs `optionalDepends`
+### `depends`, `implies`, and `optionalDepends`
 
-**`depends`** — Hard dependency. The framework will:
-1. Ensure this dependency wires before the current library
-2. Throw `MISSING_DEPENDENCY` at boot if the application hasn't included it in `libraries`
+These three fields all relate to peer libraries, but differ by exactly one bit — whether they add an ordering edge:
 
-Use for services your library actively calls. If the dependency is missing, your library can't work.
+| | Membership pull | Ordering edge | Typed on `params` | Missing = error |
+|---|:---:|:---:|:---:|:---:|
+| `depends` | ✅ (transitive closure) | ✅ | ✅ | ✅ |
+| `implies` | ✅ | ❌ | ✅ | — |
+| `optionalDepends` | ❌ | ✅ (if present) | ❌ | — |
 
-**`optionalDepends`** — Soft dependency. The framework will:
-1. Ensure this dependency wires first *if it's present*
-2. Not throw an error if it's absent
+**`depends`** — Hard dependency. The framework:
+1. Pulls this library (and its transitive `depends`) into the wired set (closure-as-membership)
+2. Ensures this dependency wires before the current library
+3. Throws `MISSING_DEPENDENCY` at boot if the dependency is somehow absent after membership resolution
+
+Use for services your library actively calls at wiring time. The `const` tuple capture means the dependency's types also travel to consumers that import only this library.
+
+**`optionalDepends`** — Soft dependency. The framework:
+1. Ensures this dependency wires first *if it's present in membership*
+2. Does **not** pull it into membership and does **not** error if it's absent
+3. Leaves the dependency untyped on `params`
 
 Use for optional integrations. Your service code must handle the case where the dependency's services are `undefined`.
+
+**`implies`** — Membership-only escape hatch. Prefer `depends` for ordering + membership. Use `implies` only when loading this library should pull in others but this library does not call them at wiring time and therefore does not need them to wire first.
 
 ```typescript
 export const MY_LIB = CreateLibrary({
   name: "my_lib",
-  depends: [DATABASE_LIB],         // always required
-  optionalDepends: [CACHE_LIB],    // nice to have
+  depends: [DATABASE_LIB],         // ordering + membership + types — always required
+  optionalDepends: [CACHE_LIB],    // order if present, no pull, untyped
   services: {
     repo: RepositoryService,
   },
 });
 ```
 
-### `implies` — transitive membership bundle
+### `implies` — membership without an ordering edge
 
-`implies` contributes **membership**, not ordering. When this library is loaded, every library in its `implies` list is pulled into the application's resolved library set and deduped — so a consumer can include just this one library and the bundle travels with it.
-
-This is the key distinction from `depends`:
-
-- `depends` / `optionalDepends` are **ordering + validation**. They control *what wires before what*, and `depends` is validated against the app's `libraries` array (`MISSING_DEPENDENCY` if absent). They do **not** add a library to membership.
-- `implies` is **membership**. It adds the listed libraries to the app's membership and dedupes them by object identity. It adds no ordering edge — ordering still flows from each member's own `depends`.
+`implies` contributes **membership** without adding an ordering edge. When this library is loaded, every library in its `implies` list is pulled into the application's resolved library set and deduped — but no ordering guarantee is added. Use this only when the carrier does not call the implied libraries at wiring time.
 
 ```typescript
 export const ANALYTICS_FRONT = CreateLibrary({
   name: "analytics_front",
-  depends: [SHARED_DB],                       // ordering: wired after SHARED_DB
-  implies: [ANALYTICS_STORE, ANALYTICS_API],  // membership: these travel with me
+  depends: [SHARED_DB],                       // ordering + membership: wired after SHARED_DB
+  implies: [ANALYTICS_STORE, ANALYTICS_API],  // membership only: these travel with me, no ordering
   services: { ... },
 });
 ```
 
-Rollups ([`RollupLibraries`](./rollup-libraries)) are accepted in `implies` and are flattened recursively.
+Groups ([`LibraryGroup`](./rollup-libraries)) are accepted in `implies` and are flattened recursively.
 
-:::tip Types of implied members travel automatically — with named `function` services
-`CreateLibrary` captures `implies` as a `const` tuple (a third type parameter on `LibraryDefinition`), so the implier's emitted `.d.ts` references each implied member by `typeof import("./member.mjs").Service` — a real module edge. The member's own `LoadedModules` augmentation rides that edge, so a consumer that imports **only** the implier gets each member's service APIs on `TServiceParams`, both **typed and wired**, with no `LoadedRollups` block and no manual re-export.
+:::tip Types of `depends` and `implies` members travel automatically — with named `function` services
+`CreateLibrary` captures both `depends` and `implies` as `const` tuples (type parameters on `LibraryDefinition`), so the carrier's emitted `.d.ts` references each dependency and implied member by `typeof import("./member.mjs").Service` — a real module edge. The member's own `LoadedModules` augmentation rides that edge, so a consumer that imports **only** the carrier gets each member's service APIs on `TServiceParams`, both **typed and wired**, with no `LoadedRollups` block and no manual re-export.
 
-This holds **only when the implied library's services are literal named `function` declarations**. An arrow / anonymous service is serialized structurally inline with no import edge, so its augmentation never travels — the member still wires, but `params.member` is untyped. For an implied member that must ship arrow services, fall back to registering the bundle on `LoadedRollups`, like a nameless rollup. See [Library composition](../../guides/library-composition).
+This holds **only when the depended-on / implied library's services are literal named `function` declarations**. An arrow / anonymous service is serialized structurally inline with no import edge, so its augmentation never travels — the member still wires, but `params.member` is untyped. For a member that must ship arrow services, fall back to registering the bundle on `LoadedRollups`. See [Library composition](../../guides/library-composition).
 :::
 
 ### `priorityInit`
@@ -109,9 +116,10 @@ Any application that imports this file gets the type augmentation for free. No r
 
 | Error cause | What it means |
 |---|---|
-| `MISSING_DEPENDENCY` | This library's `depends` entry is not in the app's `libraries` array |
+| `MISSING_DEPENDENCY` | This library's `depends` entry is not reachable in the resolved membership set |
 | `MISSING_PRIORITY_SERVICE` | A name in `priorityInit` doesn't exist in `services` |
+| `DUPLICATE_LIBRARY` | Two distinct objects share the same library name — two physical copies are installed; run `yarn dedupe` |
 
-## Version mismatch
+## Duplicate installs
 
-If an application includes two versions of the same library (e.g., direct dependency and transitive dependency resolve to different versions), the framework emits a warning and uses whichever version the application declared directly. No error is thrown.
+`DUPLICATE_LIBRARY` means two physically distinct library objects share the same name. This is not a version-arbitration case the framework can resolve — the singleton-held-globally contract means only one copy can exist. The error names both copies and points at `yarn dedupe` or manual version alignment. The framework deliberately does not pick a winner.

--- a/docs/core/reference/libraries/create-library.md
+++ b/docs/core/reference/libraries/create-library.md
@@ -118,8 +118,14 @@ Any application that imports this file gets the type augmentation for free. No r
 |---|---|
 | `MISSING_DEPENDENCY` | This library's `depends` entry is not reachable in the resolved membership set |
 | `MISSING_PRIORITY_SERVICE` | A name in `priorityInit` doesn't exist in `services` |
-| `DUPLICATE_LIBRARY` | Two distinct objects share the same library name — two physical copies are installed; run `yarn dedupe` |
+| `DUPLICATE_LIBRARY` | Two distinct objects share the same library name and neither is app-declared — an unbootable state |
 
 ## Duplicate installs
 
-`DUPLICATE_LIBRARY` means two physically distinct library objects share the same name. This is not a version-arbitration case the framework can resolve — the singleton-held-globally contract means only one copy can exist. The error names both copies and points at `yarn dedupe` or manual version alignment. The framework deliberately does not pick a winner.
+`DUPLICATE_LIBRARY` is governed by a fixed three-case rule. A library is constructed once and held as a global singleton, so exactly one object boots per name:
+
+1. **Declared in the app module** → it is authoritative.
+2. **Exactly one instance exists anywhere** → it is used.
+3. **Two distinct objects share a name, neither is app-declared** → crash. This is an unbootable, illegal state.
+
+The error states the fact only: `Duplicate library names detected: "<name>" (×N: copy#1 vs copy#2)`. The framework deliberately does not arbitrate between versions — the package manager owns that.

--- a/docs/core/reference/libraries/create-library.md
+++ b/docs/core/reference/libraries/create-library.md
@@ -15,6 +15,7 @@ export const MY_LIB = CreateLibrary({
   configuration: { ... },
   depends: [...],
   optionalDepends: [...],
+  implies: [...],
   priorityInit: [...],
 });
 ```
@@ -28,6 +29,7 @@ export const MY_LIB = CreateLibrary({
 | `configuration` | `ModuleConfiguration` | — | Config entry declarations for this library |
 | `depends` | `LibraryDefinition[]` | — | Hard dependencies — must also be in the app's `libraries` array |
 | `optionalDepends` | `LibraryDefinition[]` | — | Soft dependencies — wired first if present, no error if absent |
+| `implies` | `(LibraryDefinition \| LibraryRollup)[]` | — | Transitive bundle — libraries pulled into *membership* (not ordering) when this one loads |
 | `priorityInit` | `string[]` | — | Services to wire first within this library |
 
 ### `depends` vs `optionalDepends`
@@ -54,6 +56,30 @@ export const MY_LIB = CreateLibrary({
   },
 });
 ```
+
+### `implies` — transitive membership bundle
+
+`implies` contributes **membership**, not ordering. When this library is loaded, every library in its `implies` list is pulled into the application's resolved library set and deduped — so a consumer can include just this one library and the bundle travels with it.
+
+This is the key distinction from `depends`:
+
+- `depends` / `optionalDepends` are **ordering + validation**. They control *what wires before what*, and `depends` is validated against the app's `libraries` array (`MISSING_DEPENDENCY` if absent). They do **not** add a library to membership.
+- `implies` is **membership**. It adds the listed libraries to the app's membership and dedupes them by object identity. It adds no ordering edge — ordering still flows from each member's own `depends`.
+
+```typescript
+export const ANALYTICS_FRONT = CreateLibrary({
+  name: "analytics_front",
+  depends: [SHARED_DB],                       // ordering: wired after SHARED_DB
+  implies: [ANALYTICS_STORE, ANALYTICS_API],  // membership: these travel with me
+  services: { ... },
+});
+```
+
+Rollups ([`RollupLibraries`](./rollup-libraries)) are accepted in `implies` and are flattened recursively.
+
+:::note Types of implied members
+Because the implied libraries are named modules that the implying library imports directly, their `LoadedModules` augmentations travel with it — so their service APIs appear on `TServiceParams` for any app that includes the implier. See [Library composition](../../guides/library-composition) for the full cross-package typing rule.
+:::
 
 ### `priorityInit`
 

--- a/docs/core/reference/libraries/dependency-graph.md
+++ b/docs/core/reference/libraries/dependency-graph.md
@@ -1,6 +1,6 @@
 ---
 title: Dependency Graph
-sidebar_position: 2
+sidebar_position: 3
 description: "How buildSortOrder works, BAD_SORT, and MISSING_DEPENDENCY errors."
 ---
 

--- a/docs/core/reference/libraries/dependency-graph.md
+++ b/docs/core/reference/libraries/dependency-graph.md
@@ -37,46 +37,32 @@ B depends on A
 `BAD_SORT` is a hard error. The framework does not use proxies or deferred imports. Circular dependencies are detected immediately at boot and must be resolved structurally.
 :::
 
-## MISSING_DEPENDENCY — hard dep not in libraries
+## MISSING_DEPENDENCY — dependency object not resolvable
 
-`MISSING_DEPENDENCY` is thrown when a library has `depends: [X]` but `X` is not in the application's `libraries` array:
+`MISSING_DEPENDENCY` is thrown when a library's `depends` entry could not be resolved to any object at all after the full membership closure is computed — meaning the library object was somehow not reachable through any path. This is rare in practice because `depends` itself transitively pulls dependencies into the wired set (closure-as-membership), so a `depends` entry that is a real imported singleton is auto-pulled.
 
-```typescript
-// MY_LIB requires DATABASE_LIB
-export const MY_LIB = CreateLibrary({
-  name: "my_lib",
-  depends: [DATABASE_LIB],  // hard dependency
-  services: { ... },
-});
-
-// APPLICATION doesn't include DATABASE_LIB → MISSING_DEPENDENCY at boot
-export const MY_APP = CreateApplication({
-  libraries: [MY_LIB],   // ← DATABASE_LIB missing!
-  services: { ... },
-});
-```
-
-**Fix:** Add the missing library to `libraries`:
-
-```typescript
-export const MY_APP = CreateApplication({
-  libraries: [DATABASE_LIB, MY_LIB],
-  services: { ... },
-});
-```
+`MISSING_DEPENDENCY` means "could not resolve to any object at all" — it is not triggered merely by omitting a library from the app's `libraries` array (closure-as-membership handles that). The auto-pulled libraries are narrated in the boot log.
 
 `optionalDepends` entries are exempt — they log a message and continue if absent.
 
-## Version mismatch
+## Duplicate library names (`DUPLICATE_LIBRARY`)
 
-If the application includes the same library twice (directly and transitively), the framework emits a `warn` log and uses the version declared directly in the application's `libraries` array. No error is thrown.
+A library is constructed once and held as a global singleton. The framework applies a fixed three-case rule:
+
+1. **Declared in the app module** → it is authoritative.
+2. **Exactly one instance exists anywhere** → it is used.
+3. **Two distinct objects share the same name and neither is app-declared** → crash (`DUPLICATE_LIBRARY`).
+
+The error states the fact only: `Duplicate library names detected: "<name>" (×N: copy#1 vs copy#2)`. The framework deliberately does not arbitrate between versions — the package manager owns that.
+
+A diamond (the same singleton reached through multiple `depends` or group paths) is fine — identity dedup collapses it to one entry and boot emits a hygiene `warn`.
 
 ```mermaid
 graph LR
   App --> MY_LIB
-  App --> DATABASE_LIB_v2
-  MY_LIB --> DATABASE_LIB_v1
-  Note["Database lib version mismatch: warn emitted, v2 used"]
+  App --> DATABASE_LIB
+  MY_LIB --> DATABASE_LIB
+  Note["Same object reached via two paths: deduped, warn emitted"]
 ```
 
 ## Example dependency graph

--- a/docs/core/reference/libraries/module-extension.md
+++ b/docs/core/reference/libraries/module-extension.md
@@ -1,6 +1,6 @@
 ---
 title: Module Extension
-sidebar_position: 3
+sidebar_position: 4
 description: "createModule and ModuleExtension — the chainable API for composing and extending modules."
 ---
 

--- a/docs/core/reference/libraries/rollup-libraries.md
+++ b/docs/core/reference/libraries/rollup-libraries.md
@@ -1,0 +1,101 @@
+---
+title: RollupLibraries
+sidebar_position: 2
+description: "RollupLibraries() — compose libraries into a nameless, deduped membership unit, and the LoadedRollups type channel."
+---
+
+`RollupLibraries` composes several libraries into a single, **nameless** membership unit. List it anywhere a library list is accepted — `CreateApplication({ libraries })` or a library's `implies` — and at bootstrap it flattens into its members and dedupes.
+
+```typescript
+import { RollupLibraries, CreateApplication } from "@digital-alchemy/core";
+
+const analyticsPlugin = RollupLibraries(
+  [ANALYTICS_INGEST, ANALYTICS_API, ANALYTICS_STORE],
+  { label: "analytics" },
+);
+
+CreateApplication({
+  name: "platform",
+  libraries: [analyticsPlugin, billingPlugin, SHARED_DB], // rollups + plain libs, freely mixed
+  services: { ... },
+});
+```
+
+## Why
+
+The application `libraries` array must be a **complete, flat** enumeration of every library plus its transitive dependencies (`buildSortOrder` throws `MISSING_DEPENDENCY` for any `depends` target that is absent). For a large app organized into plugin-like groups, hand-maintaining that union is error-prone and loses any record of *which group contributed what*.
+
+`RollupLibraries` makes "these N libraries are one composable unit" a first-class, typed, deduped, introspectable value.
+
+## Signature
+
+```typescript
+function RollupLibraries<const M extends readonly RollupMember[]>(
+  members: M,
+  options?: { label?: string },
+): LibraryRollup<M>;
+```
+
+| Param | Type | Description |
+|---|---|---|
+| `members` | `(LibraryDefinition \| LibraryRollup)[]` | Libraries and/or nested rollups to compose |
+| `options.label` | `string` | Optional diagnostic label for the boot manifest — **not** a DI identity |
+
+## Semantics
+
+- **Membership only.** A rollup contributes membership; it is nameless, gets **no `LoadedModules` key**, and adds **no ordering edge**. Ordering stays entirely on each member's own `depends`, topologically sorted as always.
+- **Dedup by object identity.** The same singleton library reached through multiple rollups (or `implies`) collapses to one entry. This requires members to be **module-singleton exports** referenced by the rollups — not constructed inline per rollup.
+- **Nested rollups flatten recursively.**
+- **Same name, different object → error.** Two distinct objects sharing a name survive flattening and are then rejected by the standard duplicate-name guard (`DUPLICATE_LIBRARY`).
+- **Cycle detection.** A rollup that transitively contains itself throws `COMPOSITION_CYCLE`.
+- **Multi-path hygiene warning.** When a library enters membership via more than one path (a diamond), boot emits an informational `warn` — consider declaring it a shared base dependency. With `showExtraBootStats`, the boot manifest lists each member and the path(s) that contributed it.
+
+```typescript
+// member's own depends still orders it correctly, regardless of how membership arrived
+const ANALYTICS_STORE = CreateLibrary({
+  name: "analytics_store",
+  depends: [SHARED_DB], // SHARED_DB wires first — even if both came via the rollup
+  services: { ... },
+});
+```
+
+## Typing: the `LoadedRollups` channel
+
+`TServiceParams` is keyed off the global `LoadedModules` interface, which each library augments via declaration merging. A rollup is nameless and registers **no** `LoadedModules` key — so for a consumer that imports **only the rollup** (e.g. across a published-package boundary), the members' APIs would not otherwise appear on `TServiceParams`.
+
+To make them visible, register the rollup's members on the **`LoadedRollups`** channel in the module that defines the rollup:
+
+```typescript title="analytics/src/index.mts"
+export const analyticsPlugin = RollupLibraries(
+  [ANALYTICS_INGEST, ANALYTICS_API],
+  { label: "analytics" },
+);
+
+declare module "@digital-alchemy/core" {
+  export interface LoadedRollups {
+    analytics: {
+      analytics_ingest: typeof ANALYTICS_INGEST;
+      analytics_api: typeof ANALYTICS_API;
+    };
+  }
+}
+```
+
+The member shapes are inlined into this augmentation, which travels with the rollup import — so `params.analytics_ingest` and `params.analytics_api` are fully typed downstream. See [Library composition](../../guides/library-composition) for the full explanation of *why* this is required.
+
+:::note Membership-only consequence
+A library delivered **only** through a rollup gets its service APIs on `TServiceParams`, but — because it has no `LoadedModules` key — no typed `config.<member>` entry and no `levelOverrides` entry. Its runtime config still loads. If you need typed config, also list the library directly (or have it augment `LoadedModules` itself).
+:::
+
+## Validation errors
+
+| Error cause | What it means |
+|---|---|
+| `COMPOSITION_CYCLE` | A rollup transitively contains itself, or an `implies` chain forms a cycle |
+| `DUPLICATE_LIBRARY` | Two different objects sharing a name reached membership (e.g. via a rollup and directly) |
+
+## Related
+
+- [CreateLibrary](./create-library) — the `implies` field is the other feed into the same membership resolver
+- [Dependency Graph](./dependency-graph) — ordering, which rollups leave untouched
+- [Library composition](../../guides/library-composition) — guide: membership vs ordering, and cross-package typing

--- a/docs/core/reference/libraries/rollup-libraries.md
+++ b/docs/core/reference/libraries/rollup-libraries.md
@@ -1,75 +1,115 @@
 ---
-title: RollupLibraries
+title: LibraryGroup
 sidebar_position: 2
-description: "RollupLibraries() — compose libraries into a nameless, deduped membership unit, and the LoadedRollups type channel."
+description: "LibraryGroup() — compose libraries into a membership unit, with optional name, registry service, and the LoadedRollups type channel."
 ---
 
-`RollupLibraries` composes several libraries into a single, **nameless** membership unit. List it anywhere a library list is accepted — `CreateApplication({ libraries })` or a library's `implies` — and at bootstrap it flattens into its members and dedupes.
+`LibraryGroup` composes several libraries into a membership unit. List it anywhere a library list is accepted — `CreateApplication({ libraries })` or a library's `implies` — and at bootstrap it flattens into its members and dedupes.
 
 ```typescript
-import { RollupLibraries, CreateApplication } from "@digital-alchemy/core";
+import { LibraryGroup, CreateApplication } from "@digital-alchemy/core";
 
-const analyticsPlugin = RollupLibraries(
-  [ANALYTICS_INGEST, ANALYTICS_API, ANALYTICS_STORE],
-  { label: "analytics" },
-);
+const analyticsPlugin = LibraryGroup({
+  members: [ANALYTICS_INGEST, ANALYTICS_API, ANALYTICS_STORE],
+  name: "analytics",
+});
 
 CreateApplication({
   name: "platform",
-  libraries: [analyticsPlugin, billingPlugin, SHARED_DB], // rollups + plain libs, freely mixed
+  libraries: [analyticsPlugin, billingPlugin, SHARED_DB], // groups + plain libs, freely mixed
   services: { ... },
 });
 ```
 
 ## Why
 
-The application `libraries` array must be a **complete, flat** enumeration of every library plus its transitive dependencies (`buildSortOrder` throws `MISSING_DEPENDENCY` for any `depends` target that is absent). For a large app organized into plugin-like groups, hand-maintaining that union is error-prone and loses any record of *which group contributed what*.
+The application `libraries` array must resolve to a **complete** enumeration of every library. With closure-as-membership (`depends` transitively pulling dependencies into the wired set), most transitive libraries are auto-pulled — but explicit groups are still the right tool when you want to name, bundle, or provide a registry for a plugin-like collection.
 
-`RollupLibraries` makes "these N libraries are one composable unit" a first-class, typed, deduped, introspectable value.
+`LibraryGroup` makes "these N libraries are one composable unit" a first-class, typed, deduped, introspectable value.
 
 ## Signature
 
 ```typescript
-function RollupLibraries<const M extends readonly RollupMember[]>(
-  members: M,
-  options?: { label?: string },
-): LibraryRollup<M>;
+function LibraryGroup<const M extends readonly RollupMember[]>({
+  members,
+  name,
+  registry,
+}: {
+  members: M;
+  name?: string;
+  registry?: string;
+}): LibraryRollup<M>;
 ```
 
 | Param | Type | Description |
 |---|---|---|
-| `members` | `(LibraryDefinition \| LibraryRollup)[]` | Libraries and/or nested rollups to compose |
-| `options.label` | `string` | Optional diagnostic label for the boot manifest — **not** a DI identity |
+| `members` | `(LibraryDefinition \| LibraryGroup)[]` | Libraries and/or nested groups to compose |
+| `name` | `string` | Optional group name — earns a `LoadedModules` key and reserves a `config.<name>` namespace |
+| `registry` | `string` | Optional registry-service name — requires `name`; generates a `priorityInit` registry service |
 
 ## Semantics
 
-- **Membership only.** A rollup contributes membership; it is nameless, gets **no `LoadedModules` key**, and adds **no ordering edge**. Ordering stays entirely on each member's own `depends`, topologically sorted as always.
-- **Dedup by object identity.** The same singleton library reached through multiple rollups (or `implies`) collapses to one entry. This requires members to be **module-singleton exports** referenced by the rollups — not constructed inline per rollup.
-- **Nested rollups flatten recursively.**
-- **Same name, different object → error.** Two distinct objects sharing a name survive flattening and are then rejected by the standard duplicate-name guard (`DUPLICATE_LIBRARY`).
-- **Cycle detection.** A rollup that transitively contains itself throws `COMPOSITION_CYCLE`.
-- **Multi-path hygiene warning.** When a library enters membership via more than one path (a diamond), boot emits an informational `warn` — consider declaring it a shared base dependency. With `showExtraBootStats`, the boot manifest lists each member and the path(s) that contributed it.
+- **Membership only.** A group contributes membership; it adds **no ordering edge**. Ordering stays entirely on each member's own `depends`, topologically sorted as always.
+- **Named group.** When `name` is provided, the group earns a `LoadedModules` key and a reserved `config.<name>` namespace. Useful when the group itself should be introspectable or when consumers need a named config block.
+- **Dedup by object identity.** The same singleton library reached through multiple groups (or `implies` or `depends` closure) collapses to one entry.
+- **Nested groups flatten recursively.**
+- **Same name, different object → error.** Two distinct objects sharing a name survive flattening and are rejected by the duplicate-name guard (`DUPLICATE_LIBRARY`) — the error names both copies and points at `yarn dedupe`.
+- **Cycle detection.** A group that transitively contains itself throws `COMPOSITION_CYCLE`.
+- **Multi-path hygiene warning.** When a library enters membership via more than one path (a diamond), boot emits an informational `warn`. With `showExtraBootStats`, the boot manifest lists each member and the path(s) that contributed it.
+
+## `registry` — the plugin-registry pattern
+
+When `registry` is provided (requires `name`), `LibraryGroup` synthesizes a **carrier library** that hosts a `priorityInit` registry service. Each member is shallow-cloned with `depends: [carrier]` appended so the registry is always wired before any member reads it.
+
+The generated service exposes `register(item)` / `list()`:
+
+```typescript
+export const ANALYTICS_GROUP = LibraryGroup({
+  name: "analytics",
+  registry: "registry",
+  members: [ANALYTICS_INGEST, ANALYTICS_API],
+});
+```
+
+Members self-register using `lifecycle.onPreInit` (not at module scope, not in `onBootstrap`):
+
+```typescript title="analytics-ingest.service.mts"
+export function IngestService({ analytics, lifecycle }: TServiceParams) {
+  lifecycle.onPreInit(() => {
+    analytics.registry.register({ name: "ingest", fetch: ingestImpl });
+  });
+  // ...
+}
+```
+
+Consumers read the registry after boot:
+
+```typescript
+export function RouterService({ analytics }: TServiceParams) {
+  const adapters = analytics.registry.list();
+}
+```
 
 ```typescript
 // member's own depends still orders it correctly, regardless of how membership arrived
 const ANALYTICS_STORE = CreateLibrary({
   name: "analytics_store",
-  depends: [SHARED_DB], // SHARED_DB wires first — even if both came via the rollup
+  depends: [SHARED_DB], // SHARED_DB wires first — even if both came via the group
   services: { ... },
 });
 ```
 
 ## Typing: the `LoadedRollups` channel
 
-`TServiceParams` is keyed off the global `LoadedModules` interface, which each library augments via declaration merging. A rollup is nameless and registers **no** `LoadedModules` key — so for a consumer that imports **only the rollup** (e.g. across a published-package boundary), the members' APIs would not otherwise appear on `TServiceParams`.
+`TServiceParams` is keyed off the global `LoadedModules` interface, which each library augments via declaration merging. A group with no name registers **no** `LoadedModules` key — so for a consumer that imports **only the group** (e.g. across a published-package boundary), the members' APIs would not otherwise appear on `TServiceParams`.
 
-To make them visible, register the rollup's members on the **`LoadedRollups`** channel in the module that defines the rollup:
+To make them visible, register the group's members on the **`LoadedRollups`** channel in the module that defines the group:
 
 ```typescript title="analytics/src/index.mts"
-export const analyticsPlugin = RollupLibraries(
-  [ANALYTICS_INGEST, ANALYTICS_API],
-  { label: "analytics" },
-);
+export const analyticsPlugin = LibraryGroup({
+  name: "analytics",
+  members: [ANALYTICS_INGEST, ANALYTICS_API],
+});
 
 declare module "@digital-alchemy/core" {
   export interface LoadedRollups {
@@ -81,21 +121,26 @@ declare module "@digital-alchemy/core" {
 }
 ```
 
-The member shapes are inlined into this augmentation, which travels with the rollup import — so `params.analytics_ingest` and `params.analytics_api` are fully typed downstream. See [Library composition](../../guides/library-composition) for the full explanation of *why* this is required.
+The member shapes are inlined into this augmentation, which travels with the group import — so `params.analytics_ingest` and `params.analytics_api` are fully typed downstream. See [Library composition](../../guides/library-composition) for the full explanation of *why* this is required.
+
+:::note Type priority
+`LoadedRollups` is a **fallback** channel. Directly-listed library augmentations always win. `LoadedRollups` only fills keys not already present from a direct `LoadedModules` augmentation.
+:::
 
 :::note Membership-only consequence
-A library delivered **only** through a rollup gets its service APIs on `TServiceParams`, but — because it has no `LoadedModules` key — no typed `config.<member>` entry and no `levelOverrides` entry. Its runtime config still loads. If you need typed config, also list the library directly (or have it augment `LoadedModules` itself).
+A library delivered **only** through an unnamed group gets its service APIs on `TServiceParams`, but — because it has no `LoadedModules` key — no typed `config.<member>` entry and no `levelOverrides` entry. Its runtime config still loads. If you need typed config, also list the library directly.
 :::
 
 ## Validation errors
 
 | Error cause | What it means |
 |---|---|
-| `COMPOSITION_CYCLE` | A rollup transitively contains itself, or an `implies` chain forms a cycle |
-| `DUPLICATE_LIBRARY` | Two different objects sharing a name reached membership (e.g. via a rollup and directly) |
+| `COMPOSITION_CYCLE` | A group transitively contains itself, or an `implies`/`depends` chain forms a cycle |
+| `DUPLICATE_LIBRARY` | Two different objects sharing a name reached membership — likely two physical copies installed; run `yarn dedupe` |
+| `REGISTRY_REQUIRES_NAME` | `registry` was provided without a `name` |
 
 ## Related
 
-- [CreateLibrary](./create-library) — the `implies` field is the other feed into the same membership resolver
-- [Dependency Graph](./dependency-graph) — ordering, which rollups leave untouched
+- [CreateLibrary](./create-library) — the `implies` and `depends` fields are the other feeds into the same membership resolver
+- [Dependency Graph](./dependency-graph) — ordering, which groups leave untouched
 - [Library composition](../../guides/library-composition) — guide: membership vs ordering, and cross-package typing

--- a/docs/core/reference/libraries/rollup-libraries.md
+++ b/docs/core/reference/libraries/rollup-libraries.md
@@ -44,16 +44,16 @@ function LibraryGroup<const M extends readonly RollupMember[]>({
 | Param | Type | Description |
 |---|---|---|
 | `members` | `(LibraryDefinition \| LibraryGroup)[]` | Libraries and/or nested groups to compose |
-| `name` | `string` | Optional group name — earns a `LoadedModules` key and reserves a `config.<name>` namespace |
+| `name` | `string` | Optional group name — required when using `registry`; a plain named group does not earn a `LoadedModules` key by itself |
 | `registry` | `string` | Optional registry-service name — requires `name`; generates a `priorityInit` registry service |
 
 ## Semantics
 
 - **Membership only.** A group contributes membership; it adds **no ordering edge**. Ordering stays entirely on each member's own `depends`, topologically sorted as always.
-- **Named group.** When `name` is provided, the group earns a `LoadedModules` key and a reserved `config.<name>` namespace. Useful when the group itself should be introspectable or when consumers need a named config block.
+- **Named group.** When `name` is provided, the group has a human-readable label and is required for the `registry` option. A plain named group does **not** by itself earn a `LoadedModules` key or a `config.<name>` namespace — only a `registry`-bearing group synthesizes a carrier library named `<name>` that earns those.
 - **Dedup by object identity.** The same singleton library reached through multiple groups (or `implies` or `depends` closure) collapses to one entry.
 - **Nested groups flatten recursively.**
-- **Same name, different object → error.** Two distinct objects sharing a name survive flattening and are rejected by the duplicate-name guard (`DUPLICATE_LIBRARY`) — the error names both copies and points at `yarn dedupe`.
+- **Same name, different object → error.** Two distinct objects sharing a name survive flattening and are rejected by the duplicate-name guard (`DUPLICATE_LIBRARY`). The error states: `Duplicate library names detected: "<name>" (×N: copy#1 vs copy#2)`. See the three-case rule under [Validation errors](#validation-errors).
 - **Cycle detection.** A group that transitively contains itself throws `COMPOSITION_CYCLE`.
 - **Multi-path hygiene warning.** When a library enters membership via more than one path (a diamond), boot emits an informational `warn`. With `showExtraBootStats`, the boot manifest lists each member and the path(s) that contributed it.
 
@@ -136,7 +136,7 @@ A library delivered **only** through an unnamed group gets its service APIs on `
 | Error cause | What it means |
 |---|---|
 | `COMPOSITION_CYCLE` | A group transitively contains itself, or an `implies`/`depends` chain forms a cycle |
-| `DUPLICATE_LIBRARY` | Two different objects sharing a name reached membership — likely two physical copies installed; run `yarn dedupe` |
+| `DUPLICATE_LIBRARY` | Two distinct objects share the same name and neither is app-declared — an unbootable state. Three-case rule: (1) app-declared → authoritative; (2) exactly one instance anywhere → used; (3) two distinct objects, neither app-declared → crash. Error: `Duplicate library names detected: "<name>" (×N: copy#1 vs copy#2)`. |
 | `REGISTRY_REQUIRES_NAME` | `registry` was provided without a `name` |
 
 ## Related

--- a/src/examples/blog/declaration-emit.ts
+++ b/src/examples/blog/declaration-emit.ts
@@ -1,0 +1,74 @@
+/**
+ * Example: declaration-emit — function vs arrow services
+ * Used on: blog/function-vs-arrow-declaration-emit.mdx
+ *
+ * Both files type-check identically *inside this single program*. That is the
+ * whole trap: the difference does not exist at the source level — it only shows
+ * up in the `.d.ts` TypeScript emits, which is what a downstream package reads.
+ */
+export const files: Record<string, string> = {
+	"lighting.mts": `import { CreateLibrary, type TServiceParams } from "@digital-alchemy/core";
+
+// ✅ A named *function declaration*. In the emitted .d.ts this stays a
+//    referenceable symbol, so a library that captures LIGHTING in its
+//    \`implies\` emits \`typeof import("./lighting.mjs").Lights\` — a real
+//    module edge that carries the augmentation below to downstream consumers.
+export function Lights({ logger }: TServiceParams) {
+  let brightness = 0;
+  return {
+    dim(toPercent: number) {
+      brightness = toPercent;
+      logger.info(\`lights → \${toPercent}%\`);
+    },
+    get brightness() {
+      return brightness;
+    },
+  };
+}
+
+export const LIGHTING = CreateLibrary({
+  name: "lighting",
+  services: { Lights },
+});
+
+declare module "@digital-alchemy/core" {
+  interface LoadedModules {
+    lighting: typeof LIGHTING;
+  }
+}
+`,
+	"lighting-arrow.mts": `import { CreateLibrary, type TServiceParams } from "@digital-alchemy/core";
+
+// ❌ The exact same logic as an arrow assigned to a const. Hover \`Lights\` in
+//    both files — the inferred type is identical *here*. But this form emits
+//    \`export declare const Lights: (p: TServiceParams) => {...}\` (a structural
+//    type, no symbol to point at), so a downstream \`implies\` inlines it with
+//    NO import edge. The augmentation never travels: the service still wires,
+//    but \`params.lighting\` is untyped across a package boundary.
+export const Lights = ({ logger }: TServiceParams) => {
+  let brightness = 0;
+  return {
+    dim(toPercent: number) {
+      brightness = toPercent;
+      logger.info(\`lights → \${toPercent}%\`);
+    },
+    get brightness() {
+      return brightness;
+    },
+  };
+};
+
+export const LIGHTING = CreateLibrary({
+  name: "lighting",
+  services: { Lights },
+});
+
+declare module "@digital-alchemy/core" {
+  interface LoadedModules {
+    lighting: typeof LIGHTING;
+  }
+}
+`,
+}
+
+export const defaultFile = "lighting.mts"


### PR DESCRIPTION
## Changes

- Documents library composition: `LibraryGroup`, the `depends`/`implies`/`optionalDepends` ordering-edge model, automatic cross-package type travel, and the `registry` plugin pattern (`docs/core/guides/library-composition.md`, `docs/core/reference/libraries/*`).
- Corrects `DUPLICATE_LIBRARY` to the three-case rule and drops the `yarn dedupe` prescription; fixes the claim that a plain named group earns a `LoadedModules` key / `config` namespace (only a `registry` carrier does).
- Adds two blog posts: named-`function` vs arrow declaration-emit, and the cross-package composition design story.

Companion PR: https://github.com/Digital-Alchemy-TS/core/pull/333
