### PR TITLE
docs: align declaration-merging examples with symbols decoupling

### DIFF
--- a/docs/core/advanced/async-local-storage.md
+++ b/docs/core/advanced/async-local-storage.md
@@ -51,7 +51,6 @@ Sets the ALS data for the current context without creating a new scope. Mutates 
 ```typescript
 interface AsyncLogData {
   duration?: () => number;  // returns ms since entry — appended to log lines
-  logger?: GetLogger;       // thread-local child logger override
 }
 
 interface AsyncLocalData {
@@ -66,8 +65,7 @@ To extend `AsyncLocalData` with your own fields, use declaration merging:
 ```typescript
 declare module "@digital-alchemy/core" {
   export interface AsyncLocalData {
-    logs: AsyncLogData;      // keep the existing field
-    requestId?: string;      // add your own
+    requestId?: string;      // add your own request-scoped fields
     userId?: string;
   }
 }

--- a/docs/core/guides/dependency-injection.md
+++ b/docs/core/guides/dependency-injection.md
@@ -74,12 +74,10 @@ When `my_lib` is in `inject`, it carries all of `MY_LIB`'s service return values
 
 ## What LoadedModules actually does
 
-`LoadedModules` is an interface in `@digital-alchemy/core` that starts with only one entry:
+`LoadedModules` is an interface — re-exported by `@digital-alchemy/core` from the frozen `@digital-alchemy/symbols` package — that starts empty:
 
 ```typescript
-export interface LoadedModules {
-  boilerplate: typeof LIB_BOILERPLATE;
-}
+export interface LoadedModules {}
 ```
 
 It's designed for TypeScript interface augmentation. When you write:
@@ -96,7 +94,6 @@ TypeScript merges your declaration into the existing interface. The result is:
 
 ```typescript
 interface LoadedModules {
-  boilerplate: typeof LIB_BOILERPLATE;
   my_app: typeof MY_APP;
 }
 ```


### PR DESCRIPTION
## Changes

- Updates the `LoadedModules` example in the dependency-injection guide: the interface is now empty and re-exported by `@digital-alchemy/core` from the frozen `@digital-alchemy/symbols` package. Drops the internal `boilerplate` member from both the definition and the merge result.
- Corrects the async-local-storage guide — `AsyncLogData.logger` and the redeclared `AsyncLocalData.logs` are core-internal and no longer part of the augmentable frozen interfaces. Consumers still augment `@digital-alchemy/core` exactly as before.

Companion to the `@digital-alchemy/symbols` decoupling — symbols package https://github.com/Digital-Alchemy-TS/symbols/pull/1, core consumer https://github.com/Digital-Alchemy-TS/core/pull/335.